### PR TITLE
Update pagination after clearing search

### DIFF
--- a/src/features/Pagination.js
+++ b/src/features/Pagination.js
@@ -65,6 +65,7 @@ export class Pagination {
 
     this.afs.on("filter", () => this.update());
     this.afs.on("search", () => this.update());
+    this.afs.on("searchCleared", () => this.update());
     this.afs.on("sort", () => this.update());
 
     this.container.addEventListener("click", (e) => {


### PR DESCRIPTION
There's an issue where pagination isn't re-applied after you clear the search field:

<img width="945" height="563" alt="Peek 2026-04-22 16-12" src="https://github.com/user-attachments/assets/1a9075fa-8636-4846-afaa-4cb2ed26b356" />

See demo: https://codepen.io/Norm-Plum/pen/jEMRjjx

This PR fixes it by triggering a pagination update on the `searchCleared` event.